### PR TITLE
Regexp

### DIFF
--- a/gokay/hex.go
+++ b/gokay/hex.go
@@ -22,3 +22,33 @@ func IsHex(s *string) error {
 
 	return nil
 }
+
+var (
+	re = regexp.MustCompile("^(0x)?[0-9a-fA-F]+$")
+)
+
+// IsHex validates that the given string is a hex value
+func IsHexV2(s *string) error {
+	if s == nil {
+		return nil
+	}
+
+	if !re.MatchString(strings.ToLower(*s)) {
+		return fmt.Errorf("'%s' is not a hexadecimal string", *s)
+	}
+
+	return nil
+}
+
+// IsHex validates that the given string is a hex value
+func IsHexV3(s *string) error {
+	if s == nil {
+		return nil
+	}
+
+	if !re.MatchString(*s) {
+		return fmt.Errorf("'%s' is not a hexadecimal string", *s)
+	}
+
+	return nil
+}

--- a/gokay/hex.go
+++ b/gokay/hex.go
@@ -3,7 +3,10 @@ package gokay
 import (
 	"fmt"
 	"regexp"
-	"strings"
+)
+
+var (
+	hexRegexp = regexp.MustCompile("^(0x)?[0-9a-fA-F]+$")
 )
 
 // IsHex validates that the given string is a hex value
@@ -12,41 +15,7 @@ func IsHex(s *string) error {
 		return nil
 	}
 
-	matches, err := regexp.MatchString("^(0x)?[0-9a-f]+$", strings.ToLower(*s))
-	if err != nil {
-		return err
-	}
-	if !matches {
-		return fmt.Errorf("'%s' is not a hexadecimal string", *s)
-	}
-
-	return nil
-}
-
-var (
-	re = regexp.MustCompile("^(0x)?[0-9a-fA-F]+$")
-)
-
-// IsHex validates that the given string is a hex value
-func IsHexV2(s *string) error {
-	if s == nil {
-		return nil
-	}
-
-	if !re.MatchString(strings.ToLower(*s)) {
-		return fmt.Errorf("'%s' is not a hexadecimal string", *s)
-	}
-
-	return nil
-}
-
-// IsHex validates that the given string is a hex value
-func IsHexV3(s *string) error {
-	if s == nil {
-		return nil
-	}
-
-	if !re.MatchString(*s) {
+	if !hexRegexp.MatchString(*s) {
 		return fmt.Errorf("'%s' is not a hexadecimal string", *s)
 	}
 

--- a/gokay/hex_test.go
+++ b/gokay/hex_test.go
@@ -26,32 +26,13 @@ func TestIsHex_NotHex(t *testing.T) {
 	require.EqualError(t, IsHex(&str), "'0x1Gbcq' is not a hexadecimal string")
 }
 
-var (
-	testHex = "0x1234567890ABCDEF"
-)
+func BenchmarkIsHex(b *testing.B) {
+	benchHex := "0x1234567890ABCDEF"
+	var err error
+	for n := 0; n < b.N; n++ {
+		err = IsHex(&benchHex)
+	}
+	devNull(err)
+}
 
 func devNull(i interface{}) {}
-
-func BenchmarkHexV1(b *testing.B) {
-	var err error
-	for n := 0; n < b.N; n++ {
-		err = IsHex(&testHex)
-	}
-	devNull(err)
-}
-
-func BenchmarkHexV2(b *testing.B) {
-	var err error
-	for n := 0; n < b.N; n++ {
-		err = IsHexV2(&testHex)
-	}
-	devNull(err)
-}
-
-func BenchmarkHexV3(b *testing.B) {
-	var err error
-	for n := 0; n < b.N; n++ {
-		err = IsHexV3(&testHex)
-	}
-	devNull(err)
-}

--- a/gokay/hex_test.go
+++ b/gokay/hex_test.go
@@ -25,3 +25,33 @@ func TestIsHex_NotHex(t *testing.T) {
 	str := "0x1Gbcq"
 	require.EqualError(t, IsHex(&str), "'0x1Gbcq' is not a hexadecimal string")
 }
+
+var (
+	testHex = "0x1234567890ABCDEF"
+)
+
+func devNull(i interface{}) {}
+
+func BenchmarkHexV1(b *testing.B) {
+	var err error
+	for n := 0; n < b.N; n++ {
+		err = IsHex(&testHex)
+	}
+	devNull(err)
+}
+
+func BenchmarkHexV2(b *testing.B) {
+	var err error
+	for n := 0; n < b.N; n++ {
+		err = IsHexV2(&testHex)
+	}
+	devNull(err)
+}
+
+func BenchmarkHexV3(b *testing.B) {
+	var err error
+	for n := 0; n < b.N; n++ {
+		err = IsHexV3(&testHex)
+	}
+	devNull(err)
+}

--- a/gokay/uuid.go
+++ b/gokay/uuid.go
@@ -3,7 +3,10 @@ package gokay
 import (
 	"fmt"
 	"regexp"
-	"strings"
+)
+
+var (
+	uuidRegexp = regexp.MustCompile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$")
 )
 
 // IsUUID validates that the given string is a UUID value
@@ -12,11 +15,7 @@ func IsUUID(s *string) error {
 		return nil
 	}
 
-	matches, err := regexp.MatchString("^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", strings.ToLower(*s))
-	if err != nil {
-		return err
-	}
-	if !matches {
+	if !uuidRegexp.MatchString(*s) {
 		return fmt.Errorf("'%s' is not a UUID", *s)
 	}
 

--- a/gokay/uuid_test.go
+++ b/gokay/uuid_test.go
@@ -25,3 +25,12 @@ func TestIsUUID_NotUUIDTooLong(t *testing.T) {
 	str := "AB603c9a2a-38db-4987-932a-2f57733a29fQ"
 	require.EqualError(t, IsUUID(&str), "'AB603c9a2a-38db-4987-932a-2f57733a29fQ' is not a UUID")
 }
+
+func BenchmarkIsUUID(b *testing.B) {
+	benchUUID := "603C9a2a-38dB-4987-932a-2f57733a29f1"
+	var err error
+	for n := 0; n < b.N; n++ {
+		err = IsUUID(&benchUUID)
+	}
+	devNull(err)
+}


### PR DESCRIPTION
Ran into this code while tracing. Thought there might be room for improvement. Here is some benchmark data between the 3 versions. `V1` is the current version used with the pkg. Same is probably true for `IsUUID`. 

Can get these benchmarks from commit `544f1dc6d1f7e5a42235df0cf1af4f12f1f98ee8`
BenchmarkHexV1-8   	  100000	               11691 ns/op	   45232 B/op	      60 allocs/op
BenchmarkHexV2-8   	 2000000	       752 ns/op	      64 B/op	       2 allocs/op
BenchmarkHexV3-8   	 3000000	       546 ns/op	       0 B/op	       0 allocs/op